### PR TITLE
Use stol to avoid out-of-range exceptions

### DIFF
--- a/examples/spmm/spmm.cc
+++ b/examples/spmm/spmm.cc
@@ -627,7 +627,7 @@ static int parseOption(std::string &option, int default_value) {
     pos = option.length();
   }
   token = option.substr(0, pos);
-  N = std::stoi(token);
+  N = std::stol(token);
   option.erase(0, pos + 1);
   return N;
 }


### PR DESCRIPTION
Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>