### PR TITLE
Provide full TT and TTG names in dot output 

### DIFF
--- a/ttg/ttg/parsec/ttg.h
+++ b/ttg/ttg/parsec/ttg.h
@@ -199,7 +199,7 @@ namespace ttg_parsec {
         parsec_profiling_add_dictionary_keyword("PARSEC_TTG_BCAST_ARG_IMPL", "fill:000000", 0, NULL,
                                                 (int*)&parsec_ttg_profile_backend_bcast_arg_start,
                                                 (int*)&parsec_ttg_profile_backend_bcast_arg_end);
-        parsec_profiling_add_dictionary_keyword("PARSEC_TTG_DATACOPY", "fill:000000", 
+        parsec_profiling_add_dictionary_keyword("PARSEC_TTG_DATACOPY", "fill:000000",
                                                 sizeof(size_t), "size{int64_t}",
                                                 (int*)&parsec_ttg_profile_backend_allocate_datacopy,
                                                 (int*)&parsec_ttg_profile_backend_free_datacopy);
@@ -366,7 +366,7 @@ namespace ttg_parsec {
 #endif
     }
 
-    virtual void profile_on() override { 
+    virtual void profile_on() override {
 #if defined(PARSEC_PROF_TRACE)
       _task_profiling = true;
 #endif
@@ -405,13 +405,13 @@ namespace ttg_parsec {
     void register_new_profiling_event(const char *name, int position) {
       if(2*position >= profiling_array_size) {
         size_t new_profiling_array_size = 64 * ((2*position + 63)/64 + 1);
-        profiling_array = (int*)realloc((void*)profiling_array, 
+        profiling_array = (int*)realloc((void*)profiling_array,
                                          new_profiling_array_size * sizeof(int));
         memset((void*)&profiling_array[profiling_array_size], 0, sizeof(int)*(new_profiling_array_size - profiling_array_size));
         profiling_array_size = new_profiling_array_size;
         tpool->profiling_array = profiling_array;
       }
-     
+
       assert(0 == tpool->profiling_array[2*position]);
       assert(0 == tpool->profiling_array[2*position+1]);
       parsec_profiling_add_dictionary_keyword(name, "fill:000000", 0, NULL,
@@ -459,7 +459,7 @@ namespace ttg_parsec {
 
     typedef void (*parsec_static_op_t)(void *);  // static_op will be cast to this type
 
-    const parsec_symbol_t parsec_taskclass_param0 = { 
+    const parsec_symbol_t parsec_taskclass_param0 = {
       .flags = PARSEC_SYMBOL_IS_STANDALONE|PARSEC_SYMBOL_IS_GLOBAL,
       .name = "HASH0",
       .context_index = 0,
@@ -467,7 +467,7 @@ namespace ttg_parsec {
       .max = nullptr,
       .expr_inc = nullptr,
       .cst_inc = 0 };
-    const parsec_symbol_t parsec_taskclass_param1 = { 
+    const parsec_symbol_t parsec_taskclass_param1 = {
       .flags = PARSEC_SYMBOL_IS_STANDALONE|PARSEC_SYMBOL_IS_GLOBAL,
       .name = "HASH1",
       .context_index = 1,
@@ -475,7 +475,7 @@ namespace ttg_parsec {
       .max = nullptr,
       .expr_inc = nullptr,
       .cst_inc = 0 };
-    const parsec_symbol_t parsec_taskclass_param2 = { 
+    const parsec_symbol_t parsec_taskclass_param2 = {
       .flags = PARSEC_SYMBOL_IS_STANDALONE|PARSEC_SYMBOL_IS_GLOBAL,
       .name = "KEY0",
       .context_index = 2,
@@ -483,7 +483,7 @@ namespace ttg_parsec {
       .max = nullptr,
       .expr_inc = nullptr,
       .cst_inc = 0 };
-    const parsec_symbol_t parsec_taskclass_param3 = { 
+    const parsec_symbol_t parsec_taskclass_param3 = {
       .flags = PARSEC_SYMBOL_IS_STANDALONE|PARSEC_SYMBOL_IS_GLOBAL,
       .name = "KEY1",
       .context_index = 3,
@@ -724,9 +724,9 @@ namespace ttg_parsec {
       if(ttg::default_execution_context().impl().profiling()) {
         copy->size = sizeof(Value);
         copy->uid = parsec_atomic_fetch_inc_int64(&parsec_ttg_data_copy_uid);
-        parsec_profiling_ts_trace_flags(ttg::default_execution_context().impl().parsec_ttg_profile_backend_allocate_datacopy, 
-                                        static_cast<uint64_t>(copy->uid), 
-                                        PROFILE_OBJECT_ID_NULL, &copy->size, 
+        parsec_profiling_ts_trace_flags(ttg::default_execution_context().impl().parsec_ttg_profile_backend_allocate_datacopy,
+                                        static_cast<uint64_t>(copy->uid),
+                                        PROFILE_OBJECT_ID_NULL, &copy->size,
                                         PARSEC_PROFILING_EVENT_COUNTER|PARSEC_PROFILING_EVENT_HAS_INFO);
       }
 #endif
@@ -848,9 +848,9 @@ namespace ttg_parsec {
 #if defined(PARSEC_PROF_TRACE) && defined(PARSEC_TTG_PROFILE_BACKEND)
           // Keep track of additional memory usage
           if(ttg::default_execution_context().impl().profiling()) {
-            parsec_profiling_ts_trace_flags(ttg::default_execution_context().impl().parsec_ttg_profile_backend_free_datacopy, 
-                                            static_cast<uint64_t>(copy->uid), 
-                                            PROFILE_OBJECT_ID_NULL, &copy->size, 
+            parsec_profiling_ts_trace_flags(ttg::default_execution_context().impl().parsec_ttg_profile_backend_free_datacopy,
+                                            static_cast<uint64_t>(copy->uid),
+                                            PROFILE_OBJECT_ID_NULL, &copy->size,
                                             PARSEC_PROFILING_EVENT_COUNTER|PARSEC_PROFILING_EVENT_HAS_INFO);
           }
 #endif
@@ -981,7 +981,7 @@ namespace ttg_parsec {
   inline void ttg_finalize() {
     // We need to notify the current taskpool of termination if we are in user termination detection mode
     // or the parsec_context_wait() in destroy_worlds() will never complete
-    if(0 == ttg::default_execution_context().rank()) 
+    if(0 == ttg::default_execution_context().rank())
       ttg::default_execution_context().impl().final_task();
     ttg::detail::set_default_world(ttg::World{});  // reset the default world
     ttg::detail::destroy_worlds<ttg_parsec::WorldImpl>();
@@ -1639,7 +1639,7 @@ namespace ttg_parsec {
           parsec_hash_table_nolock_insert(&tasks_table, &task->tt_ht_item);
           if( world_impl.dag_profiling() ) {
 #if defined(PARSEC_PROF_GRAPHER)
-            parsec_prof_grapher_task(&task->parsec_task, world_impl.execution_stream()->th_id, 0, 
+            parsec_prof_grapher_task(&task->parsec_task, world_impl.execution_stream()->th_id, 0,
                                      key_hash(make_key(task->parsec_task.taskpool, task->parsec_task.locals), nullptr));
 #endif
           }
@@ -1829,7 +1829,7 @@ namespace ttg_parsec {
           if(world.impl().profiling()) {
             parsec_profiling_ts_trace(world.impl().parsec_ttg_profile_backend_set_arg_end, 0, 0, NULL);
           }
-#endif          
+#endif
         return;
       }
       // the target task is remote. Pack the information and send it to
@@ -2613,8 +2613,10 @@ namespace ttg_parsec {
       if(buffer_size == 0)
         return buffer;
 
+      task_t *task = (task_t*)t;
+
       if constexpr (ttg::meta::is_void_v<keyT>) {
-        snprintf(buffer, buffer_size, "%s()[]<%d>", t->task_class->name, t->priority);
+        snprintf(buffer, buffer_size, "%s()[]<%d>", task->tt->get_full_name().c_str(), t->priority);
       }  else {
         // we use the locals array as a scratchpad to store the hash of the key and its actual address
         // locals[0] amd locals[1] hold the hash, while locals[2] and locals[3] hold the key pointer
@@ -2626,7 +2628,7 @@ namespace ttg_parsec {
         std::replace(keystr.begin(), keystr.end(), '(', ':');
         std::replace(keystr.begin(), keystr.end(), ')', ':');
 
-        snprintf(buffer, buffer_size, "%s(%s)[]<%d>", t->task_class->name, keystr.c_str(), t->priority);
+        snprintf(buffer, buffer_size, "%s(%s)[]<%d>", task->tt->get_full_name().c_str(), keystr.c_str(), t->priority);
       }
       return buffer;
     }
@@ -2802,12 +2804,12 @@ namespace ttg_parsec {
              std::forward<keymapT>(keymap), std::forward<priomapT>(priomap)) {}
 
     // Destructor checks for unexecuted tasks
-    virtual ~TT() { 
+    virtual ~TT() {
       if(nullptr != self.name ) {
         free((void*)self.name);
         self.name = nullptr;
       }
-      release(); 
+      release();
     }
 
     static void ht_iter_cb(void *item, void *cb_data) {

--- a/ttg/ttg/tt.h
+++ b/ttg/ttg/tt.h
@@ -89,7 +89,7 @@ namespace ttg {
 
    private:
     void own_my_tts() const {
-      for (auto &op : tts) op->owning_ttg = this;
+      for (auto &op : tts) op->set_ttg(this);
     }
 
   };


### PR DESCRIPTION
Adds a function get_full_name() to the TTBase to query the full name
qualified with the parent TTGs, i.e., GrandParent::Parent::Me.

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>